### PR TITLE
Added method to get session list

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ pip install wallbox
 ### getSessionList(chargerId, startDate, endDate)
 
 - provides the list of charging sessions between startDate and endDate
-- startDate and endDate are provided in Python datetime format
+- startDate and endDate are provided in Python datetime format (i.e. 2021-05-04 08:41:12.765644)
 
 ## Simple example
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ pip install wallbox
 
 ```python
 from wallbox import Wallbox
+import time
+import datetime
 
 w = Wallbox("user@email", "password")
 
@@ -67,6 +69,10 @@ for chargerId in w.getChargersList():
     chargerStatus = w.getChargerStatus(chargerId)
     print(f"Charger Status: {chargerStatus}")
     print(f"Lock Charger {chargerId}")
+    endDate = datetime.datetime.now()
+    startDate = endDate - datetime.timedelta(days = 30)
+    sessionList = w.getSessionList(chargerId, startDate, endDate)
+    print(f"Session List: {sessionList}")
     w.lockCharger(chargerId)
     time.sleep(10)
     chargerStatus = w.getChargerStatus(chargerId)

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ pip install wallbox
 ### getSessionList(chargerId, startDate, endDate)
 
 - provides the list of charging sessions between startDate and endDate
-- startDate and endDate are provided in python datetime format
+- startDate and endDate are provided in Python datetime format
 
 ## Simple example
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ pip install wallbox
 
 - resumes a charging session
 
+### getSessionList(chargerId, startDate, endDate)
+
+- provides the list of charging sessions between startDate and endDate
+- startDate and endDate are provided in python datetime format
+
 ## Simple example
 
 ```python

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(name):
 
 setup(
     name="wallbox",
-    version="0.4.4",
+    version="0.4.5",
     description="Module for interacting with Wallbox EV charger api",
     long_description=read("README.md"),
     long_description_content_type="text/markdown",

--- a/wallbox/wallbox.py
+++ b/wallbox/wallbox.py
@@ -118,7 +118,7 @@ class Wallbox:
 
     def getSessionList(self, chargerId, startDate, endDate):
         try:
-            payload = {'charger': chargerId, 'start_date': startDate, 'end_date': }
+            payload = {'charger': chargerId, 'start_date': startDate, 'end_date': endDate }
 
             response = requests.get(
                 f"{self.baseUrl}v4/sessions/stats", params=payload, headers=self.headers

--- a/wallbox/wallbox.py
+++ b/wallbox/wallbox.py
@@ -118,7 +118,7 @@ class Wallbox:
 
     def getSessionList(self, chargerId, startDate, endDate):
         try:
-            payload = {'charger': chargerId, 'start_date': startDate, 'end_date': endDate }
+            payload = {'charger': chargerId, 'start_date': startDate.timestamp(), 'end_date': endDate.timestamp() }
 
             response = requests.get(
                 f"{self.baseUrl}v4/sessions/stats", params=payload, headers=self.headers

--- a/wallbox/wallbox.py
+++ b/wallbox/wallbox.py
@@ -115,3 +115,15 @@ class Wallbox:
         except requests.exceptions.HTTPError as err:
             raise (err)
         return json.loads(response.text)
+
+    def getSessionList(self, chargerId, startDate, endDate):
+        try:
+            payload = {'charger': chargerId, 'start_date': startDate, 'end_date': }
+
+            response = requests.get(
+                f"{self.baseUrl}v4/sessions/stats", params=payload, headers=self.headers
+            )
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as err:
+            raise (err)
+        return json.loads(response.text)


### PR DESCRIPTION
The module has been extended by a method getSessionList(chargerId, startDate, endDate) which gets the complete detailed list of loading sessions in a specific timeframe.

The method has been tested with a Wallbox Pulsar Plus. The readme and sample code have been extended.