### PR TITLE
Include status_description to status_id mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ Python Module interface for Wallbox EV chargers api
 
 ## Requirements
 
-Python 3.7 or older
-Python modules "requests>=2.22.0", "simplejson>=3.16.0"
+Python 3.7 or older Python modules "requests>=2.22.0", "simplejson>=3.16.0"
+
+Python module "aenum>=3.1.8"
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ pip install wallbox
 ## Simple example
 
 ```python
-from wallbox import Wallbox
+from wallbox import Wallbox, Statuses
 import time
 import datetime
 
@@ -86,4 +86,7 @@ for chargerId in w.getChargersList():
     time.sleep(10)
     chargerStatus = w.getChargerStatus(chargerId)
     print(f"Charger {chargerId} lock status {chargerStatus['config_data']['locked']}")
+
+    # Print the status the charger is currently in using the status id
+    print(f"Charger Mode: {Statuses(chargerStatus['status_id']).name}")
 ```

--- a/wallbox/__init__.py
+++ b/wallbox/__init__.py
@@ -1,2 +1,3 @@
 # Wallbox EV module __init__.py
 from wallbox.wallbox import Wallbox
+from wallbox.statuses import Statuses

--- a/wallbox/statuses.py
+++ b/wallbox/statuses.py
@@ -1,0 +1,14 @@
+from aenum import MultiValueEnum
+
+
+class Statuses(MultiValueEnum):
+    WAITING = 164, 180, 181, 183, 184, 185, 186, 187, 188, 189,
+    CHARGING = 193, 194, 195,
+    READY = 161, 162,
+    PAUSED = 178, 182,
+    SCHEDULED = 177, 179,
+    DISCHARGING = 196,
+    ERROR = 14, 15,
+    DISCONNECTED = 0, 163, None,
+    LOCKED = 209, 210, 165,
+    UPDATING = 166


### PR DESCRIPTION
Include an option to map the status_id property returned by the getChargerStatus() method to an Enum