### PR TITLE
Divide jwtTokenTtl by 1000 to compensate for milisecond timestamp

### DIFF
--- a/wallbox/wallbox.py
+++ b/wallbox/wallbox.py
@@ -30,7 +30,7 @@ class Wallbox:
         return self._requestGetTimeout
 
     def authenticate(self):
-        if self.jwtToken != "" and self.jwtTokenTtl > datetime.timestamp(datetime.now()):
+        if self.jwtToken != "" and (self.jwtTokenTtl/1000) > datetime.timestamp(datetime.now()):
             return
 
         try:


### PR DESCRIPTION
The Ttl timestamp from the API seems to have changed in formatting and now has 13 characters (includes miliseconds). This results in this comparison not working anymore. Which in turn causes errors downstream (Home Assistant integration broken).