### PR TITLE
Add rounding to jwtTokenTTL division

### DIFF
--- a/wallbox/wallbox.py
+++ b/wallbox/wallbox.py
@@ -30,7 +30,9 @@ class Wallbox:
         return self._requestGetTimeout
 
     def authenticate(self):
-        if self.jwtToken != "" and (self.jwtTokenTtl/1000) > datetime.timestamp(datetime.now()):
+        if self.jwtToken != "" and round(
+            (self.jwtTokenTtl / 1000) - 120, 0
+        ) > datetime.timestamp(datetime.now()):
             return
 
         try:

--- a/wallbox/wallbox.py
+++ b/wallbox/wallbox.py
@@ -12,12 +12,13 @@ import json
 
 
 class Wallbox:
-    def __init__(self, username, password, requestGetTimeout = None):
+    def __init__(self, username, password, requestGetTimeout = None, jwtTokenDrift = 0):
         self.username = username
         self.password = password
         self._requestGetTimeout = requestGetTimeout
         self.baseUrl = "https://api.wall-box.com/"
         self.authUrl = "https://user-api.wall-box.com/"
+        self.jwtTokenDrift = jwtTokenDrift
         self.jwtToken = ""
         self.jwtTokenTtl = 0
         self.headers = {
@@ -31,7 +32,7 @@ class Wallbox:
 
     def authenticate(self):
         if self.jwtToken != "" and round(
-            (self.jwtTokenTtl / 1000) - 120, 0
+            (self.jwtTokenTtl / 1000) - jwtTokenDrift, 0
         ) > datetime.timestamp(datetime.now()):
             return
 


### PR DESCRIPTION
A further addition to prevent token expiration:
 1. round the token after division (to prevent it being bigger by only 3 ms)
 2. subtract 2 minutes (you will always authenticate first and than do something with the wallbox, 2 minutes gives you time for your actions)