### PR TITLE
Adding a global timeout support, and setting a default timeout (+ retry) + powerboost + schedules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,6 @@ dmypy.json
 test_liviu.py
 APIDEBUG.md
 .DS_Store
+
+# PyCharm
+ .idea

--- a/tests/test_scratch_pad_for_dev.py
+++ b/tests/test_scratch_pad_for_dev.py
@@ -22,6 +22,7 @@ if __name__ == "__main__":
     max_charging_current = 32
     w.setMaxChargingCurrent(chargers[0], max_charging_current)
 
+    a = w.getChargerSchedules(chargers[0])
 
     d3 = w.getChargerStatus(chargers[0])
     if d3['config_data']['max_charging_current'] == max_charging_current:

--- a/tests/test_scratch_pad_for_dev.py
+++ b/tests/test_scratch_pad_for_dev.py
@@ -1,0 +1,38 @@
+from datetime import datetime, timezone, timedelta
+import requests
+from wallbox import Wallbox
+
+from credentials_for_test_do_not_commit import PASSWORD, USER_NAME
+
+if __name__ == "__main__":
+
+    w = Wallbox(username=USER_NAME, password=PASSWORD, jwtTokenDrift=30)
+    w.authenticate()
+    chargers = w.getChargersList()
+    d = w.getChargerStatus(chargers[0])
+
+    energy_price = 0.23
+    w.setEnergyCost(chargers[0], energy_price)
+    d2 = w.getChargerStatus(chargers[0])
+    if d2['config_data']['energy_price'] == energy_price:
+        print("ok")
+
+    charge_sessions = w.getSessionList(chargers[0], startDate=datetime.now() - timedelta(days=3), endDate=datetime.now())
+
+    max_charging_current = 32
+    w.setMaxChargingCurrent(chargers[0], max_charging_current)
+
+
+    d3 = w.getChargerStatus(chargers[0])
+    if d3['config_data']['max_charging_current'] == max_charging_current:
+        print("ok")
+
+    #test timeout
+    w._requestTimeout = 0.00001
+    try:
+        w.getChargerStatus(chargers[0])
+    except requests.exceptions.Timeout as err:
+        print("ok")
+
+
+

--- a/wallbox/wallbox.py
+++ b/wallbox/wallbox.py
@@ -7,7 +7,11 @@ from datetime import datetime
 from requests.auth import HTTPBasicAuth
 import requests
 import json
-import bearerauth
+
+try:
+    from .bearerauth import BearerAuth
+except:
+    from bearerauth import BearerAuth
 
 
 DEFAULT_TIMEOUT_S = 5
@@ -50,7 +54,7 @@ class Wallbox:
                   > datetime.timestamp(datetime.now())):
                 # try to refresh token
                 auth_path = "users/refresh-token"
-                auth = bearerauth.BearerAuth(self.jwtRefreshToken)
+                auth = BearerAuth(self.jwtRefreshToken)
 
         try:
             response = requests.get(

--- a/wallbox/wallbox.py
+++ b/wallbox/wallbox.py
@@ -113,12 +113,6 @@ class Wallbox:
         self.jwtRefreshTokenTtl = json.loads(response.text)["data"]["attributes"]["refresh_token_ttl"]
         self.headers["Authorization"] = f"Bearer {self.jwtToken}"
 
-
-
-
-
-
-
     def getChargersList(self):
         chargerIds = []
         response = self._get_helper(f"{self.baseUrl}v3/chargers/groups")

--- a/wallbox/wallbox.py
+++ b/wallbox/wallbox.py
@@ -8,11 +8,7 @@ from requests.auth import HTTPBasicAuth
 import requests
 import json
 
-try:
-    from .bearerauth import BearerAuth
-except:
-    from bearerauth import BearerAuth
-
+from wallbox.bearerauth import BearerAuth
 
 DEFAULT_TIMEOUT_S = 5
 RETRY_ON_TIMEOUT_NUMBER = 3

--- a/wallbox/wallbox.py
+++ b/wallbox/wallbox.py
@@ -10,11 +10,11 @@ from requests.auth import HTTPBasicAuth
 import requests
 import json
 
-from wallbox.bearerauth import BearerAuth
+from .bearerauth import BearerAuth
 
 
 class Wallbox:
-    def __init__(self, username, password, requestGetTimeout = None, jwtTokenDrift = 0):
+    def __init__(self, username, password, requestGetTimeout = 5, jwtTokenDrift = 0):
         self.username = username
         self.password = password
         self._requestGetTimeout = requestGetTimeout
@@ -30,6 +30,7 @@ class Wallbox:
             "Content-Type": "application/json;charset=UTF-8",
             "User-Agent": "HomeAssistantWallboxPlugin/1.0.0",
         }
+        self._num_retry = 3
 
     @property
     def requestGetTimeout(self):
@@ -68,125 +69,123 @@ class Wallbox:
         self.jwtRefreshTokenTtl = json.loads(response.text)["data"]["attributes"]["refresh_token_ttl"]
         self.headers["Authorization"] = f"Bearer {self.jwtToken}"
 
+
+    def _get_helper(self, url, **kwargs):
+
+        for i in range(self._num_retry):
+            try:
+                response = requests.get(
+                    url,
+                    headers=self.headers,
+                    timeout=self._requestGetTimeout,
+                    **kwargs
+                )
+                response.raise_for_status()
+                return response
+
+            except requests.exceptions.Timeout as err:
+                # Ok we can continue trying it is a timeout
+                if i >= self._num_retry:
+                    raise (err)
+            except requests.exceptions.HTTPError as err:
+                #has been raised for HTTP errors only shoud trace it
+                raise (err)
+            except requests.exceptions.RequestException as err:
+                #Any other exception from requests (Connection errors, Too many redirects, etc
+                raise (err)
+
+    def _put_helper(self, url, **kwargs):
+
+        for i in range(self._num_retry):
+            try:
+                response = requests.put(
+                    url,
+                    headers=self.headers,
+                    timeout=self._requestGetTimeout
+                    **kwargs
+                )
+                response.raise_for_status()
+                return response
+
+            except requests.exceptions.Timeout as err:
+                # Ok we can continue trying it is a timeout
+                if i >= self._num_retry:
+                    raise (err)
+            except requests.exceptions.HTTPError as err:
+                #has been raised for HTTP errors only shoud trace it
+                raise (err)
+            except requests.exceptions.RequestException as err:
+                #Any other exception from requests (Connection errors, Too many redirects, etc
+                raise (err)
+
+    def _post_helper(self, url, **kwargs):
+
+        for i in range(self._num_retry):
+            try:
+                response = requests.post(
+                    url,
+                    headers=self.headers,
+                    timeout=self._requestGetTimeout,
+                    **kwargs
+                )
+                response.raise_for_status()
+                return response
+
+            except requests.exceptions.Timeout as err:
+                # Ok we can continue trying it is a timeout
+                if i >= self._num_retry:
+                    raise (err)
+            except requests.exceptions.HTTPError as err:
+                #has been raised for HTTP errors only shoud trace it
+                raise (err)
+            except requests.exceptions.RequestException as err:
+                #Any other exception from requests (Connection errors, Too many redirects, etc
+                raise (err)
+
+
     def getChargersList(self):
         chargerIds = []
-        try:
-            response = requests.get(
-                f"{self.baseUrl}v3/chargers/groups", headers=self.headers,
-                timeout=self._requestGetTimeout
-            )
-            response.raise_for_status()
-        except requests.exceptions.HTTPError as err:
-            raise (err)
+        response = self._get_helper(f"{self.baseUrl}v3/chargers/groups")
         for group in json.loads(response.text)["result"]["groups"]:
             for charger in group["chargers"]:
                 chargerIds.append(charger["id"])
         return chargerIds
 
     def getChargerStatus(self, chargerId):
-        try:
-            response = requests.get(
-                f"{self.baseUrl}chargers/status/{chargerId}", headers=self.headers,
-                timeout=self._requestGetTimeout
-            )
-            response.raise_for_status()
-        except requests.exceptions.HTTPError as err:
-            raise (err)
+        response = self._get_helper(f"{self.baseUrl}chargers/status/{chargerId}")
         return json.loads(response.text)
 
+
+
     def unlockCharger(self, chargerId):
-        try:
-            response = requests.put(
-                f"{self.baseUrl}v2/charger/{chargerId}",
-                headers=self.headers,
-                data='{"locked":0}',
-            )
-            response.raise_for_status()
-        except requests.exceptions.HTTPError as err:
-            raise (err)
+        response = self._put_helper(url=f"{self.baseUrl}v2/charger/{chargerId}", data='{"locked":0}')
         return json.loads(response.text)
 
     def lockCharger(self, chargerId):
-        try:
-            response = requests.put(
-                f"{self.baseUrl}v2/charger/{chargerId}",
-                headers=self.headers,
-                data='{"locked":1}',
-            )
-            response.raise_for_status()
-        except requests.exceptions.HTTPError as err:
-            raise (err)
+        response = self._put_helper(url=f"{self.baseUrl}v2/charger/{chargerId}", data='{"locked":1}')
         return json.loads(response.text)
 
     def setMaxChargingCurrent(self, chargerId, newMaxChargingCurrentValue):
-        try:
-            response = requests.put(
-                f"{self.baseUrl}v2/charger/{chargerId}",
-                headers=self.headers,
-                data=f'{{ "maxChargingCurrent":{newMaxChargingCurrentValue}}}',
-            )
-            response.raise_for_status()
-        except requests.exceptions.HTTPError as err:
-            raise (err)
+        response = self._put_helper(url=f"{self.baseUrl}v2/charger/{chargerId}", data=f'{{ "maxChargingCurrent":{newMaxChargingCurrentValue}}}')
         return json.loads(response.text)
 
     def pauseChargingSession(self, chargerId):
-        try:
-            response = requests.post(
-                f"{self.baseUrl}v3/chargers/{chargerId}/remote-action",
-                headers=self.headers,
-                data='{"action":2}',
-            )
-            response.raise_for_status()
-        except requests.exceptions.HTTPError as err:
-            raise (err)
+        response = self._post_helper(url=f"{self.baseUrl}v3/chargers/{chargerId}/remote-action", data='{"action":2}')
         return json.loads(response.text)
 
     def resumeChargingSession(self, chargerId):
-        try:
-            response = requests.post(
-                f"{self.baseUrl}v3/chargers/{chargerId}/remote-action",
-                headers=self.headers,
-                data='{"action":1}',
-            )
-            response.raise_for_status()
-        except requests.exceptions.HTTPError as err:
-            raise (err)
+        response = self._post_helper(url=f"{self.baseUrl}v3/chargers/{chargerId}/remote-action", data='{"action":1}')
         return json.loads(response.text)
 
     def restartCharger(self, chargerId):
-        try:
-            response = requests.post(
-                f"{self.baseUrl}v3/chargers/{chargerId}/remote-action",
-                headers=self.headers,
-                data='{"action":3}',
-            )
-            response.raise_for_status()
-        except requests.exceptions.HTTPError as err:
-            raise (err)
+        response = self._post_helper(url=f"{self.baseUrl}v3/chargers/{chargerId}/remote-action", data='{"action":3}')
         return json.loads(response.text)
 
     def getSessionList(self, chargerId, startDate, endDate):
-        try:
-            payload = {'charger': chargerId, 'start_date': startDate.timestamp(), 'end_date': endDate.timestamp() }
-
-            response = requests.get(
-                f"{self.baseUrl}v4/sessions/stats", params=payload, headers=self.headers,
-                timeout=self._requestGetTimeout
-            )
-            response.raise_for_status()
-        except requests.exceptions.HTTPError as err:
-            raise (err)
+        payload = {'charger': chargerId, 'start_date': startDate.timestamp(), 'end_date': endDate.timestamp()}
+        response = self._get_helper(url=f"{self.baseUrl}v4/sessions/stats", params=payload)
         return json.loads(response.text)
 
     def setEnergyCost(self, chargerId, energyCost):
-        try:
-            response = requests.post(
-                f"{self.baseUrl}chargers/config/{chargerId}",
-                headers=self.headers,
-                json={'energyCost': energyCost},
-            )
-            response.raise_for_status()
-        except requests.exceptions.HTTPError as err:
-            raise (err)
+        response = self._post_helper(url=f"{self.baseUrl}chargers/config/{chargerId}", json={'energyCost': energyCost})
         return json.loads(response.text)

--- a/wallbox/wallbox.py
+++ b/wallbox/wallbox.py
@@ -153,3 +153,35 @@ class Wallbox:
     def setEnergyCost(self, chargerId, energyCost):
         response = self._post_helper(url=f"{self.baseUrl}chargers/config/{chargerId}", json={'energyCost': energyCost})
         return json.loads(response.text)
+
+
+    def setIcpMaxCurrent(self, chargerId, newIcpMaxCurrentValue):
+        response = self._post_helper(url=f"{self.baseUrl}chargers/config/{chargerId}", json={'icp_max_current': newIcpMaxCurrentValue})
+        return json.loads(response.text)
+
+    def getChargerSchedules(self, chargerId):
+        response = self._get_helper(f"{self.baseUrl}chargers/{chargerId}/schedules")
+        return json.loads(response.text)
+
+    """
+     Example request:
+     {
+         'schedules': [{
+             'id': 0,
+             'chargerId': 42,
+             'enable': 1,
+             'max_current': 1,
+             'max_energy': 0,
+             'days': {'friday': True, 'monday': True, 'saturday': True, 'sunday': True, 'thursday': True,
+                      'tuesday': True, 'wednesday': True},
+             'start': '2100',
+             'stop': '0500'
+         }]
+     }
+     Where id is the position to add/replace
+     """
+    def setChargerSchedules(self, chargerId, newSchedules):
+         for s in newSchedules.get('schedules', []):
+             s['chargerId'] = chargerId
+         response = self._post_helper(url=f"{self.baseUrl}chargers/{chargerId}/schedules", json=newSchedules)
+         return json.loads(response.text)


### PR DESCRIPTION
Hi,

The today implementation has used in Homessitant is used without applying a timeout to the wallbox library .... so the library hangs once in a while due to the Wallbox server not answering.
Anyway from the doc, request shouldn't be used without a timeout set. I've added a default one, a number of retry in case of timeout, and a timeout not only on get request but on all request in the library.

UPDATE : added the support for schedule and ICP from https://github.com/cliviu74/wallbox/pull/35 (thanks https://github.com/nanomad !)

Hope this help!
BR
Thomas