### PR TITLE
adding "action:9" to switch back to schedule after manually pausing

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ pip install wallbox
 
 ### resumeSchedule(chargerId)
 
-- revert charger back to default schedule after manually starting a charging session
+- revert charger back to default schedule after manually starting a charging session, it reverts the charger back into "Eco Smart and Scheduled" charing mode, if used.
 
 ### getSessionList(chargerId, startDate, endDate)
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ pip install wallbox
 
 - resumes a charging session
 
+### resumeSchedule(chargerId)
+
+- revert charger back to default schedule after manually starting a charging session
+
 ### getSessionList(chargerId, startDate, endDate)
 
 - provides the list of charging sessions between startDate and endDate

--- a/wallbox/wallbox.py
+++ b/wallbox/wallbox.py
@@ -154,6 +154,18 @@ class Wallbox:
             raise (err)
         return json.loads(response.text)
 
+    def resumeSchedule(self, chargerId):
+        try:
+            response = requests.post(
+                f"{self.baseUrl}v3/chargers/{chargerId}/remote-action",
+                headers=self.headers,
+                data='{"action":9}',
+            )
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as err:
+            raise (err)
+        return json.loads(response.text)
+
     def restartCharger(self, chargerId):
         try:
             response = requests.post(


### PR DESCRIPTION
When you run scheduled sessions, but also optimize the prizing using EPEX Spot pricing to manually start and stop charing the charger does not return back into the desired "Scheduled" state (state code 179), but stays in paused (cde 182).

with the new function you can put the charger back into the desired scheduled state as documented here: https://github.com/SKB-CGN/wallbox