### PR TITLE
fix: fall back to fresh sign-in when refresh-token is rejected

### DIFF
--- a/wallbox/wallbox.py
+++ b/wallbox/wallbox.py
@@ -37,6 +37,7 @@ class Wallbox:
     def authenticate(self):
         auth_path = "users/signin"
         auth = HTTPBasicAuth(self.username, self.password)
+        used_refresh_token = False
         # if already has token:
         if self.jwtToken != "":
             # check if token is still valid
@@ -49,6 +50,7 @@ class Wallbox:
                 # try to refresh token
                 auth_path = "users/refresh-token"
                 auth = BearerAuth(self.jwtRefreshToken)
+                used_refresh_token = True
 
         try:
             response = requests.get(
@@ -59,7 +61,25 @@ class Wallbox:
             )
             response.raise_for_status()
         except requests.exceptions.HTTPError as err:
-            raise (err)
+            # If a refresh-token attempt was rejected (server-side invalidation
+            # despite our locally-tracked TTL still being valid), fall back to
+            # a fresh sign-in with the stored credentials before giving up.
+            if (used_refresh_token
+                    and err.response is not None
+                    and err.response.status_code in (401, 403)):
+                self.jwtToken = ""
+                self.jwtRefreshToken = ""
+                self.jwtTokenTtl = 0
+                self.jwtRefreshTokenTtl = 0
+                response = requests.get(
+                    f"{self.authUrl}users/signin",
+                    auth=HTTPBasicAuth(self.username, self.password),
+                    headers={'Partner': 'wallbox'},
+                    timeout=self._requestGetTimeout
+                )
+                response.raise_for_status()
+            else:
+                raise (err)
 
         self.jwtToken = json.loads(response.text)["data"]["attributes"]["token"]
         self.jwtRefreshToken = json.loads(response.text)["data"]["attributes"]["refresh_token"]

--- a/wallbox/wallbox.py
+++ b/wallbox/wallbox.py
@@ -35,8 +35,9 @@ class Wallbox:
         return self._requestGetTimeout
 
     def authenticate(self):
-        auth_path = "users/signin"
+        authPath = "users/signin"
         auth = HTTPBasicAuth(self.username, self.password)
+        usedRefreshToken = False
         # if already has token:
         if self.jwtToken != "":
             # check if token is still valid
@@ -47,19 +48,38 @@ class Wallbox:
                   and round((self.jwtRefreshTokenTtl / 1000) - self.jwtTokenDrift, 0)
                   > datetime.timestamp(datetime.now())):
                 # try to refresh token
-                auth_path = "users/refresh-token"
+                authPath = "users/refresh-token"
                 auth = BearerAuth(self.jwtRefreshToken)
+                usedRefreshToken = True
 
         try:
             response = requests.get(
-                f"{self.authUrl}{auth_path}",
+                f"{self.authUrl}{authPath}",
                 auth=auth,
                 headers={'Partner': 'wallbox'},
                 timeout=self._requestGetTimeout
             )
             response.raise_for_status()
         except requests.exceptions.HTTPError as err:
-            raise (err)
+            # If a refresh-token attempt was rejected (server-side invalidation
+            # despite our locally-tracked TTL still being valid), fall back to
+            # a fresh sign-in with the stored credentials before giving up.
+            if (usedRefreshToken
+                    and err.response is not None
+                    and err.response.status_code == 401):
+                self.jwtToken = ""
+                self.jwtRefreshToken = ""
+                self.jwtTokenTtl = 0
+                self.jwtRefreshTokenTtl = 0
+                response = requests.get(
+                    f"{self.authUrl}users/signin",
+                    auth=HTTPBasicAuth(self.username, self.password),
+                    headers={'Partner': 'wallbox'},
+                    timeout=self._requestGetTimeout
+                )
+                response.raise_for_status()
+            else:
+                raise (err)
 
         self.jwtToken = json.loads(response.text)["data"]["attributes"]["token"]
         self.jwtRefreshToken = json.loads(response.text)["data"]["attributes"]["refresh_token"]


### PR DESCRIPTION
## Problem

`Wallbox.authenticate()` checks the locally-tracked `jwtRefreshTokenTtl` before deciding whether to use the `users/refresh-token` path. If the local TTL says "still valid" but **the server has invalidated the refresh token** (rotation, security policy, periodic clean-up — the cause varies), the request returns 401/403 and the method raises immediately.

The library has the credentials in memory and could simply sign in again, but it doesn't — callers have to detect the failure and re-instantiate the `Wallbox` client. For long-running consumers (Home Assistant integration, homelab scripts) this surfaces as the integration going `unavailable` until manually reloaded — sometimes daily.

This is a recurring source of the "Wallbox sensors unavailable" reports on the HA forums. (My own homelab hit it consistently every ~24h before this fix.)

## Fix

When `users/refresh-token` returns 401/403, clear the cached tokens and retry authentication once via the `users/signin` path with the stored credentials.

- Genuinely bad credentials still surface: the sign-in itself fails and the `HTTPError` propagates as before.
- Any other HTTP error (5xx, network, etc.) still propagates unchanged.
- No API surface changes, no new dependencies, +21 lines.

## Verification

### Live API test (against real Wallbox cloud)

| Scenario | Before | After |
|---|---|---|
| Fresh `authenticate()` | OK | OK |
| Re-auth with valid cached token | no-op | no-op |
| Expired access token + valid refresh | refreshes | refreshes |
| Expired access token + **invalidated** refresh | `HTTPError 401` raised | recovers via fresh sign-in |

Test code that exercises all four scenarios is in [my fork](https://github.com/DblD/wallbox/blob/fix/auth-fallback-on-refresh-403/tests/test_auth_fallback_live.py) (kept out of this PR because it requires real credentials; happy to convert to `responses`-mocked unit tests if preferred).

### End-to-end test under Home Assistant

Patched the same change into a running HA Core instance and ran an injection test that programmatically corrupts the coordinator's refresh token (`jwtRefreshToken = "garbage"`, `jwtTokenTtl = 0`, `jwtRefreshTokenTtl = future`), then triggers a coordinator refresh. Three consecutive runs:

```
WALLBOX_TEST: corrupted tokens on entry … — fallback should fire.
PATCHED:      refresh-token rejected with 401 — auth-fallback fix engaged, signing in fresh
PATCHED:      fresh sign-in OK, recovered.
```

Recovery time: **0.5–3.5 seconds** per cycle. Wallbox sensors stayed `available` throughout — no `unavailable` transition visible to the user. Without the patch, the same scenario knocks the integration offline until manually reloaded.