### PR TITLE
Transparent 429 retry with Retry-After + exponential backoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,3 +188,51 @@ Through experimentation, we have found that adding a 60 seconds delay between AP
 We will be looking for a solution to this issue, in the meantime we recommend you catch the 429 exceptions and implement exponential backoffs or add 60 seconds delay between api calls.
 
 June 19 2025 - API ratelimit seems to have been improved. Please be aware this can happen again so continue implementing backoff/retries to the upstream API.
+
+## Retry-on-429 (built in)
+
+The library now retries 429 responses transparently using `urllib3.Retry`. The
+`Retry-After` header is honored when present; otherwise an exponential backoff
+is applied. Once retries are exhausted the same `requests.HTTPError` you would
+have seen previously is raised, so existing callers do not need to change.
+
+The defaults are conservative (3 retries, `backoffFactor=1.0`) and can be tuned
+at construction time:
+
+```python
+w = Wallbox(user, password, maxRetries=5, backoffFactor=2.0)
+```
+
+5xx responses are intentionally **not** retried: a few POST endpoints in this
+library are non-idempotent (`restartCharger`, `updateFirmware`) and a transient
+server error after the device has already accepted the action could otherwise
+trigger a duplicate. Auth failures (401/403) are also not retried so that bad
+credentials surface immediately rather than burning the retry budget. Network
+errors (DNS, connection refused, timeouts) are not retried either — that
+decision belongs to a separate change.
+
+### Behaviour and observability
+
+Failure semantics callers should expect:
+
+| Outcome | Caller sees |
+|---|---|
+| Successful call | decoded JSON / status code |
+| 429, retry succeeds | decoded JSON (retry happens transparently) |
+| 429, retries exhausted | `requests.HTTPError` with `response.status_code == 429` |
+| 401 / 403 (auth) | `requests.HTTPError` immediately, no retry |
+| Other 4xx | `requests.HTTPError` immediately, no retry |
+| 5xx | `requests.HTTPError` immediately, no retry |
+| Network error | `requests.ConnectionError` / `requests.Timeout` immediately, no retry |
+
+The library does not emit its own log records. urllib3 logs each retry at
+`WARNING` level on the `urllib3.connectionpool` logger — callers who want
+visibility into retries can configure that logger:
+
+```python
+import logging
+logging.getLogger("urllib3.connectionpool").setLevel(logging.WARNING)
+```
+
+In Home Assistant this surfaces in the integration's debug log when the user
+enables debug logging for the wallbox integration.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+-r requirements.txt
+pytest>=7.0
+pytest-httpserver>=1.0
+requests-mock>=1.11

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     url="https://github.com/cliviu74/wallbox",
     license="Apache 2",
     packages=["wallbox"],
-    install_requires=["requests>=2.22.0", "aenum>=3.1.8"],
+    install_requires=["requests>=2.22.0", "aenum>=3.1.8", "urllib3>=1.26.0"],
     python_requires=">=3.7",
     classifiers=["Programming Language :: Python :: 3",],
 )

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,264 @@
+"""
+Tests for the 429 retry behavior introduced on the Wallbox session.
+
+Three layers of coverage:
+
+1. TestRetryConfiguration — verifies the Retry adapter is mounted on the
+   session with the configuration we expect.
+2. TestExistingErrorContract — verifies non-retryable errors continue to
+   raise requests.HTTPError exactly as before, using requests-mock.
+3. TestRetryBehaviour — end-to-end behavioural tests against a real local
+   HTTP server (pytest-httpserver). These exercise the full HTTP path
+   including the urllib3 Retry adapter, which requests-mock bypasses.
+"""
+
+import time
+
+import pytest
+import requests
+import requests_mock
+
+from wallbox import Wallbox
+
+
+def _retry(session):
+    """Pull the configured Retry object off a session's https adapter."""
+    return session.get_adapter("https://example.com/").max_retries
+
+
+class TestRetryConfiguration:
+    def test_retry_adapter_is_mounted_for_https(self):
+        w = Wallbox("user", "pass")
+        adapter = w._session.get_adapter("https://example.com/")
+        assert adapter is not None
+        assert hasattr(adapter, "max_retries")
+
+    def test_status_forcelist_is_429_only(self):
+        # 5xx is intentionally excluded: some POST endpoints in the lib are
+        # not idempotent (restartCharger, updateFirmware) and silently
+        # retrying them on a transient server error could cause the action
+        # to fire twice. 429 is always safe to retry — by definition the
+        # server has not processed the request.
+        retry = _retry(Wallbox("user", "pass")._session)
+        assert retry.status_forcelist == (429,)
+
+    def test_status_forcelist_excludes_auth_and_other_4xx(self):
+        # Auth failures must not be transparently retried, otherwise bad
+        # credentials would silently burn through the retry budget.
+        retry = _retry(Wallbox("user", "pass")._session)
+        for code in (400, 401, 403, 404, 500, 502, 503, 504):
+            assert code not in retry.status_forcelist
+
+    def test_allowed_methods_cover_all_verbs_in_use(self):
+        retry = _retry(Wallbox("user", "pass")._session)
+        assert {"GET", "POST", "PUT"} <= set(retry.allowed_methods)
+
+    def test_respects_retry_after_header(self):
+        retry = _retry(Wallbox("user", "pass")._session)
+        assert retry.respect_retry_after_header is True
+
+    def test_does_not_raise_on_status(self):
+        # raise_on_status=False keeps the existing HTTPError contract: callers
+        # see requests.HTTPError, not urllib3.MaxRetryError / RetryError.
+        retry = _retry(Wallbox("user", "pass")._session)
+        assert retry.raise_on_status is False
+
+    def test_default_retry_budget(self):
+        retry = _retry(Wallbox("user", "pass")._session)
+        assert retry.total == 3
+        assert retry.backoff_factor == 1.0
+
+    def test_connect_and_read_retries_disabled(self):
+        # Network errors (DNS, connection refused, read timeout) must not be
+        # retried by this PR. The retry budget is for 429 only — silently
+        # retrying network failures is a separate decision.
+        retry = _retry(Wallbox("user", "pass")._session)
+        assert retry.connect == 0
+        assert retry.read == 0
+
+    def test_retry_budget_is_tunable(self):
+        retry = _retry(Wallbox("user", "pass", maxRetries=5, backoffFactor=2.5)._session)
+        assert retry.total == 5
+        assert retry.backoff_factor == 2.5
+
+
+class TestExistingErrorContract:
+    """
+    Sanity checks that introducing the retry adapter has not altered the
+    exception type seen by callers for non-retryable failures.
+
+    Note: requests_mock.Mocker(session=...) replaces the session's adapters
+    with its own, so the Retry adapter is bypassed for the duration of these
+    tests. That is intentional here — these tests cover the post-retry path
+    (i.e. what the caller sees once retries are exhausted or never happened).
+    Retry-loop behaviour itself is provided by urllib3 and covered by its
+    own test suite; this PR verifies our configuration plugs into it
+    correctly via the TestRetryConfiguration class above.
+    """
+
+    def _authed_client(self):
+        w = Wallbox("user", "pass")
+        # Skip authenticate() — these tests target post-auth methods.
+        w.headers["Authorization"] = "Bearer fake"
+        return w
+
+    def test_404_still_raises_http_error(self):
+        w = self._authed_client()
+        with requests_mock.Mocker(session=w._session) as m:
+            m.get(f"{w.baseUrl}chargers/status/123", status_code=404)
+            with pytest.raises(requests.exceptions.HTTPError):
+                w.getChargerStatus(123)
+
+    def test_400_still_raises_http_error(self):
+        w = self._authed_client()
+        with requests_mock.Mocker(session=w._session) as m:
+            m.put(f"{w.baseUrl}v2/charger/123", status_code=400)
+            with pytest.raises(requests.exceptions.HTTPError):
+                w.lockCharger(123)
+
+    def test_success_returns_decoded_payload(self):
+        w = self._authed_client()
+        with requests_mock.Mocker(session=w._session) as m:
+            m.get(
+                f"{w.baseUrl}chargers/status/123",
+                json={"status_id": 194, "name": "test"},
+            )
+            result = w.getChargerStatus(123)
+            assert result["status_id"] == 194
+
+
+class TestRetryBehaviour:
+    """
+    End-to-end tests using pytest-httpserver. Unlike requests-mock, this
+    spins up a real localhost HTTP server, so requests travel through the
+    full urllib3 Retry adapter and the retry behaviour is actually
+    exercised — not just the configuration we declared.
+
+    These tests use a very small backoffFactor so that retry sleeps don't
+    slow the suite down.
+    """
+
+    def _wallbox(self, httpserver, **kwargs):
+        kwargs.setdefault("backoffFactor", 0.001)
+        w = Wallbox("user", "pass", **kwargs)
+        url = httpserver.url_for("/")
+        if not url.endswith("/"):
+            url += "/"
+        w.baseUrl = url
+        w.authUrl = url
+        # The production session mounts the retry adapter on https:// only,
+        # because the Wallbox API is https. pytest-httpserver runs plaintext
+        # localhost, so for these tests we mirror the retry adapter onto
+        # http:// — keeping production https-only while still exercising the
+        # full Retry path in the test suite.
+        w._session.mount("http://", w._session.get_adapter("https://example.com/"))
+        # Skip authenticate() — these tests target post-auth methods.
+        w.headers["Authorization"] = "Bearer fake"
+        return w
+
+    def test_429_then_200_triggers_one_retry_and_succeeds(self, httpserver):
+        # First request gets a 429, second gets a 200. The lib should retry
+        # transparently and the caller should see the decoded 200 payload.
+        httpserver.expect_oneshot_request(
+            "/v3/chargers/groups"
+        ).respond_with_data("rate limited", status=429)
+        httpserver.expect_oneshot_request(
+            "/v3/chargers/groups"
+        ).respond_with_json(
+            {"result": {"groups": [{"chargers": [{"id": 42}]}]}}
+        )
+
+        w = self._wallbox(httpserver)
+        result = w.getChargersList()
+
+        assert result == [42]
+        assert len(httpserver.log) == 2  # initial + 1 retry
+
+    def test_429_forever_exhausts_retries_and_raises_http_error(self, httpserver):
+        # Server returns 429 to every request. After maxRetries=2 the lib
+        # should raise the HTTPError that callers expect (not RetryError /
+        # MaxRetryError). Total requests = 1 initial + 2 retries = 3.
+        httpserver.expect_request("/v3/chargers/groups").respond_with_data(
+            "rate limited", status=429
+        )
+
+        w = self._wallbox(httpserver, maxRetries=2)
+
+        with pytest.raises(requests.exceptions.HTTPError) as excinfo:
+            w.getChargersList()
+
+        assert excinfo.value.response.status_code == 429
+        assert len(httpserver.log) == 3
+
+    def test_retry_after_header_is_honored(self, httpserver):
+        # Server replies 429 with Retry-After: 1, then 200 on retry. With
+        # respect_retry_after_header=True the lib should sleep ~1s between
+        # attempts. With it disabled, the test would complete in well under
+        # 100ms (backoffFactor=0.001), so a 0.9s lower bound is a wide,
+        # non-flaky boundary.
+        httpserver.expect_oneshot_request(
+            "/v3/chargers/groups"
+        ).respond_with_data(
+            "rate limited", status=429, headers={"Retry-After": "1"}
+        )
+        httpserver.expect_oneshot_request(
+            "/v3/chargers/groups"
+        ).respond_with_json({"result": {"groups": []}})
+
+        w = self._wallbox(httpserver)
+        start = time.monotonic()
+        w.getChargersList()
+        elapsed = time.monotonic() - start
+
+        assert elapsed >= 0.9, f"expected ~1s wait from Retry-After, got {elapsed:.3f}s"
+        assert len(httpserver.log) == 2
+
+    def test_401_is_not_retried(self, httpserver):
+        # Auth failures must surface immediately. Otherwise bad credentials
+        # would silently consume the entire retry budget on every call.
+        httpserver.expect_request("/v3/chargers/groups").respond_with_data(
+            "unauthorized", status=401
+        )
+
+        w = self._wallbox(httpserver, maxRetries=3)
+
+        with pytest.raises(requests.exceptions.HTTPError) as excinfo:
+            w.getChargersList()
+
+        assert excinfo.value.response.status_code == 401
+        # Exactly one request — no retry.
+        assert len(httpserver.log) == 1
+
+    def test_connection_error_is_not_retried(self):
+        # Network failures (DNS, connection refused, timeout) must surface
+        # immediately, not be silently retried — that scope belongs to a
+        # separate decision and a separate PR. The retry budget is for 429
+        # only.
+        #
+        # We use a deliberately slow backoffFactor here so that *if* connect
+        # retries fired they would take noticeably long (3 sleeps of
+        # 0.1 + 0.2 + 0.4 = 0.7s). With connect retries disabled the call
+        # should fail in well under that window.
+        import socket
+        sock = socket.socket()
+        sock.bind(("127.0.0.1", 0))
+        closed_port = sock.getsockname()[1]
+        sock.close()
+
+        w = Wallbox("user", "pass", maxRetries=3, backoffFactor=0.1)
+        # Mirror the retry adapter onto http:// so this test actually
+        # exercises connect=0 through our adapter (production session is
+        # https-only — see _wallbox fixture for the same reasoning).
+        w._session.mount("http://", w._session.get_adapter("https://example.com/"))
+        w.baseUrl = f"http://127.0.0.1:{closed_port}/"
+        w.headers["Authorization"] = "Bearer fake"
+
+        start = time.monotonic()
+        with pytest.raises(requests.exceptions.ConnectionError):
+            w.getChargersList()
+        elapsed = time.monotonic() - start
+
+        assert elapsed < 0.3, (
+            f"connection error should fail fast, took {elapsed:.3f}s — "
+            "indicates network errors are being retried"
+        )

--- a/wallbox/wallbox.py
+++ b/wallbox/wallbox.py
@@ -5,7 +5,9 @@ Wallbox class
 """
 
 from datetime import datetime
+from requests.adapters import HTTPAdapter
 from requests.auth import HTTPBasicAuth
+from urllib3.util.retry import Retry
 import requests
 import json
 
@@ -13,7 +15,15 @@ from wallbox.bearerauth import BearerAuth
 
 
 class Wallbox:
-    def __init__(self, username, password, requestGetTimeout = None, jwtTokenDrift = 0):
+    def __init__(
+        self,
+        username,
+        password,
+        requestGetTimeout=None,
+        jwtTokenDrift=0,
+        maxRetries=3,
+        backoffFactor=1.0,
+    ):
         self.username = username
         self.password = password
         self._requestGetTimeout = requestGetTimeout
@@ -29,6 +39,35 @@ class Wallbox:
             "Content-Type": "application/json;charset=UTF-8",
             "User-Agent": "HomeAssistantWallboxPlugin/1.0.0",
         }
+        self._session = self._buildSession(maxRetries, backoffFactor)
+
+    @staticmethod
+    def _buildSession(maxRetries, backoffFactor):
+        # Retry on rate-limit (429) responses only. Retry-After headers are
+        # honored automatically; if absent, urllib3 falls back to exponential
+        # backoff (backoffFactor * 2^attempt). 5xx responses are intentionally
+        # excluded from the forcelist because some POST endpoints in this lib
+        # are not idempotent (restartCharger, updateFirmware) and a transient
+        # 5xx after the device has already accepted the action could otherwise
+        # trigger a duplicate. Network errors (connect=0, read=0) are likewise
+        # not retried — that decision belongs to a separate change with its
+        # own discussion. raise_on_status is disabled so callers continue to
+        # receive requests.HTTPError once retries are exhausted, preserving
+        # the existing exception contract.
+        retry = Retry(
+            total=maxRetries,
+            connect=0,
+            read=0,
+            status_forcelist=(429,),
+            allowed_methods=frozenset(["GET", "POST", "PUT", "DELETE"]),
+            backoff_factor=backoffFactor,
+            respect_retry_after_header=True,
+            raise_on_status=False,
+        )
+        session = requests.Session()
+        adapter = HTTPAdapter(max_retries=retry)
+        session.mount("https://", adapter)
+        return session
 
     @property
     def requestGetTimeout(self):
@@ -53,7 +92,7 @@ class Wallbox:
                 usedRefreshToken = True
 
         try:
-            response = requests.get(
+            response = self._session.get(
                 f"{self.authUrl}{authPath}",
                 auth=auth,
                 headers={'Partner': 'wallbox'},
@@ -71,7 +110,7 @@ class Wallbox:
                 self.jwtRefreshToken = ""
                 self.jwtTokenTtl = 0
                 self.jwtRefreshTokenTtl = 0
-                response = requests.get(
+                response = self._session.get(
                     f"{self.authUrl}users/signin",
                     auth=HTTPBasicAuth(self.username, self.password),
                     headers={'Partner': 'wallbox'},
@@ -90,7 +129,7 @@ class Wallbox:
     def getChargersList(self):
         chargerIds = []
         try:
-            response = requests.get(
+            response = self._session.get(
                 f"{self.baseUrl}v3/chargers/groups",
                 headers=self.headers,
                 timeout=self._requestGetTimeout
@@ -105,7 +144,7 @@ class Wallbox:
 
     def getChargerStatus(self, chargerId):
         try:
-            response = requests.get(
+            response = self._session.get(
                 f"{self.baseUrl}chargers/status/{chargerId}", 
                 headers=self.headers,
                 timeout=self._requestGetTimeout
@@ -117,7 +156,7 @@ class Wallbox:
 
     def unlockCharger(self, chargerId):
         try:
-            response = requests.put(
+            response = self._session.put(
                 f"{self.baseUrl}v2/charger/{chargerId}",
                 headers=self.headers,
                 data='{"locked":0}',
@@ -130,7 +169,7 @@ class Wallbox:
 
     def lockCharger(self, chargerId):
         try:
-            response = requests.put(
+            response = self._session.put(
                 f"{self.baseUrl}v2/charger/{chargerId}",
                 headers=self.headers,
                 data='{"locked":1}',
@@ -143,7 +182,7 @@ class Wallbox:
 
     def setMaxChargingCurrent(self, chargerId, newMaxChargingCurrentValue):
         try:
-            response = requests.put(
+            response = self._session.put(
                 f"{self.baseUrl}v2/charger/{chargerId}",
                 headers=self.headers,
                 data=f'{{ "maxChargingCurrent":{newMaxChargingCurrentValue}}}',
@@ -156,7 +195,7 @@ class Wallbox:
 
     def pauseChargingSession(self, chargerId):
         try:
-            response = requests.post(
+            response = self._session.post(
                 f"{self.baseUrl}v3/chargers/{chargerId}/remote-action",
                 headers=self.headers,
                 data='{"action":2}',
@@ -169,7 +208,7 @@ class Wallbox:
 
     def resumeChargingSession(self, chargerId):
         try:
-            response = requests.post(
+            response = self._session.post(
                 f"{self.baseUrl}v3/chargers/{chargerId}/remote-action",
                 headers=self.headers,
                 data='{"action":1}',
@@ -182,7 +221,7 @@ class Wallbox:
 
     def resumeSchedule(self, chargerId):
         try:
-            response = requests.post(
+            response = self._session.post(
                 f"{self.baseUrl}v3/chargers/{chargerId}/remote-action",
                 headers=self.headers,
                 data='{"action":9}',
@@ -195,7 +234,7 @@ class Wallbox:
 
     def restartCharger(self, chargerId):
         try:
-            response = requests.post(
+            response = self._session.post(
                 f"{self.baseUrl}v3/chargers/{chargerId}/remote-action",
                 headers=self.headers,
                 data='{"action":3}',
@@ -208,7 +247,7 @@ class Wallbox:
 
     def updateFirmware(self, chargerId):
         try:
-            response = requests.post(
+            response = self._session.post(
                 f"{self.baseUrl}v3/chargers/{chargerId}/remote-action",
                 headers=self.headers,
                 data='{"action":5}',
@@ -223,7 +262,7 @@ class Wallbox:
         try:
             payload = {'charger': chargerId, 'start_date': startDate.timestamp(), 'end_date': endDate.timestamp() }
 
-            response = requests.get(
+            response = self._session.get(
                 f"{self.baseUrl}v4/sessions/stats",
                 params=payload,
                 headers=self.headers,
@@ -236,7 +275,7 @@ class Wallbox:
 
     def setEnergyCost(self, chargerId, energyCost):
         try:
-            response = requests.post(
+            response = self._session.post(
                 f"{self.baseUrl}chargers/config/{chargerId}",
                 headers=self.headers,
                 json={'energyCost': energyCost},
@@ -250,7 +289,7 @@ class Wallbox:
 
     def setIcpMaxCurrent(self, chargerId, newIcpMaxCurrentValue):
         try:
-            response = requests.post(
+            response = self._session.post(
                 f"{self.baseUrl}chargers/config/{chargerId}",
                 headers=self.headers,
                 json={'icp_max_current': newIcpMaxCurrentValue},
@@ -263,7 +302,7 @@ class Wallbox:
     
     def getChargerSchedules(self, chargerId):
         try:
-            response = requests.get(
+            response = self._session.get(
                 f"{self.baseUrl}chargers/{chargerId}/schedules",
                 headers=self.headers,
                 timeout=self._requestGetTimeout
@@ -279,7 +318,7 @@ class Wallbox:
             for schedule in newSchedules.get('schedules', []):
                 schedule['chargerId'] = chargerId
 
-            response = requests.post(
+            response = self._session.post(
                 f"{self.baseUrl}chargers/{chargerId}/schedules",
                 headers=self.headers,
                 json=newSchedules,
@@ -292,7 +331,7 @@ class Wallbox:
 
     def enableEcoSmart(self, chargerId, mode: int = 0):
         try:
-            response = requests.put(
+            response = self._session.put(
                 f"{self.baseUrl}v4/chargers/{chargerId}/eco-smart",
                 headers=self.headers,
                 json={
@@ -310,7 +349,7 @@ class Wallbox:
 
     def disableEcoSmart(self, chargerId):
         try:
-            response = requests.put(
+            response = self._session.put(
                 f"{self.baseUrl}v4/chargers/{chargerId}/eco-smart",
                 headers=self.headers,
                 json={


### PR DESCRIPTION
## Summary

Adds transparent retry on 429 responses, addressing the rate-limit problem flagged in #68 and the README warning. Long-running consumers (notably the Home Assistant integration) currently lose connectivity on the first 429 and stay offline until manually reloaded — this PR makes the library survive normal rate-limit weather without any caller-side changes.

## How

A single `requests.Session` is mounted on `Wallbox.__init__` with an `HTTPAdapter` whose `max_retries` is a `urllib3.Retry` configured for:

- `status_forcelist=(429,)` — see scoping note below
- `allowed_methods=GET, POST, PUT, DELETE` — see note below
- `connect=0, read=0` — network errors are not retried (see scoping note)
- `respect_retry_after_header=True` — honors the server's `Retry-After`
- `backoff_factor=1.0` — exponential fallback when `Retry-After` is absent (~1s, 2s, 4s)
- `raise_on_status=False` — preserves the existing `requests.HTTPError` contract once retries are exhausted

Every `requests.get/post/put` call site in `wallbox.py` is mechanically swapped for `self._session.get/post/put`. No method signatures change.

### Note on `allowed_methods` including DELETE

The library does not currently issue any DELETE requests, but DELETE is kept in `allowed_methods` for two reasons:

1. **HTTP-spec idempotency**: DELETE is idempotent by definition, so it sits in the same retry-safety family as GET and PUT. urllib3's own default `allowed_methods` includes DELETE for exactly this reason.
2. **Abstraction completeness**: `_session` is the canonical retry-enabled HTTP session for the wallbox API. Enumerating it by HTTP-spec property (idempotent verbs + the POST we explicitly opted into) reads more cleanly than enumerating by current-usage. If someone adds a DELETE-using method later, retries fire automatically rather than silently regressing.

This is a small judgment call — happy to tighten to `("GET", "POST", "PUT")` if you prefer the whitelist to track actual usage strictly. Either is defensible.

## Scoping decisions

**429 only — 5xx is intentionally not in the forcelist.** Two POST endpoints in this lib are not idempotent: `restartCharger` (action 3) and `updateFirmware` (action 5). Retrying these on a transient 5xx after the device has already accepted the request could fire the action twice, with `updateFirmware` carrying the same risk the README already warns about ("can brick your charger"). 429 is always safe to retry — by definition the server has not processed the request.

**Auth failures (401/403) are excluded** so bad credentials surface immediately rather than burning the retry budget.

**Network errors are also excluded (`connect=0, read=0`).** urllib3.Retry would otherwise retry connection errors, DNS failures, and read timeouts by default. Silently retrying these is a behaviour change beyond this PR's stated scope and would mask real configuration errors behind extra wait time. The retry budget is reserved for 429 only.

## Backwards compatibility and behaviour

The lib's failure semantics, post-PR:

| Outcome | Caller sees |
|---|---|
| Successful call | decoded JSON / status code |
| 429, retry succeeds | decoded JSON (retry happens transparently) |
| 429, retries exhausted | `requests.HTTPError` (status 429) |
| 401 / 403 (auth) | `requests.HTTPError` immediately |
| Other 4xx | `requests.HTTPError` immediately |
| 5xx | `requests.HTTPError` immediately |
| Network error | `requests.ConnectionError` / `Timeout` immediately |

Two new constructor kwargs make the budget tunable for callers who want different behaviour (named in camelCase to match `requestGetTimeout` / `jwtTokenDrift`):

```python
w = Wallbox(user, password, maxRetries=5, backoffFactor=2.0)
```

## Observability

The lib itself does not emit log records — preserving parity with the rest of the codebase. urllib3 logs each retry at `WARNING` level on the `urllib3.connectionpool` logger, so callers who want visibility can configure that logger:

```python
import logging
logging.getLogger("urllib3.connectionpool").setLevel(logging.WARNING)
```

In Home Assistant this surfaces in the integration's debug log when the user enables debug logging. Adding lib-native logging is plausible as a follow-up if you'd prefer that, but it felt out of scope for this PR.

## Dependency floor

A `urllib3>=1.26.0` floor is added to `setup.py install_requires`. The `Retry(allowed_methods=...)` kwarg this PR uses was renamed from `method_whitelist` in urllib3 1.26.0; without the floor, an end-user installing on the existing `requests>=2.22.0` lower bound could land on `urllib3 1.25.x` and hit a `TypeError` at construction time. Anyone with a modern `requests` already satisfies `>=1.26.0`.

## Tests

The repo had no test scaffolding, so this PR adds one in three layers:

| Layer | Purpose | Tests | Tool |
|---|---|---|---|
| `TestRetryConfiguration` | adapter and Retry config sanity | 9 | inspection |
| `TestExistingErrorContract` | non-retryable `HTTPError` contract preserved | 3 | `requests-mock` |
| `TestRetryBehaviour` | end-to-end retries through the real HTTP path | 5 | `pytest-httpserver` |

The behavioural layer matters because `requests-mock` swaps in its own adapter and bypasses the urllib3 Retry machinery. `pytest-httpserver` spins up a real localhost server so requests travel through the full urllib3 Retry path and the retry behaviour is actually exercised. The behavioural layer covers:

- `429 → 200` triggers exactly one retry and returns the decoded payload
- `429 forever` exhausts the retry budget and raises `requests.HTTPError` (not `RetryError`)
- A `Retry-After: 1` header is honored (timing-bounded assertion)
- A `401` is **not** retried (single request, immediate `HTTPError`)
- A connection refused is **not** retried (timing-bounded — fast fail)

Each behavioural test was verified before commit by mutating the relevant Retry config (e.g. dropping 429 from the forcelist, flipping `raise_on_status`, disabling `respect_retry_after_header`, adding 401 to the forcelist, or removing `connect=0/read=0`) to confirm the test fails for the expected reason. The `connect=0, read=0` change specifically followed strict red-green TDD: the test failed naturally before the fix was applied, then passed after.

```
$ pytest tests/ -v
=========== 17 passed in 1.55s ===========
```

`requirements-dev.txt` is added with `pytest`, `requests-mock`, and `pytest-httpserver` on top of the runtime requirements. Test code uses Python's standard snake_case convention for test method names and local variables (pytest discovery norm); production code is uniformly camelCase.

## Tested locally

Smoke-tested against the live Wallbox API (Home Assistant context) — normal calls behave exactly as before, no regressions visible. I do not have a reliable way to force-trigger a 429 from the live API on demand, so the retry path itself is exercised through the test suite rather than against production.

## Out of scope (happy to file separately)

- Switching `getChargerStatus` to the v4 endpoint that `@jorisdrenth` documented in #68 — different concern, larger surface
- A local minimum-poll-interval cache as a defensive layer
- Async support
- Retrying transient 5xx for the safe, idempotent verbs only — would need a second adapter
- Lib-native logging (e.g. structured retry events) — separate design conversation

Refs: #68